### PR TITLE
A fix for the utf-8 encoding issue with ruby 1.9.2

### DIFF
--- a/lib/mms2r/media/sprint.rb
+++ b/lib/mms2r/media/sprint.rb
@@ -185,7 +185,8 @@ module MMS2R
       def sprint_write_file(type, content, file = nil)
         file = sprint_temp_file(type) if file.nil?
         log("#{self.class} writing file #{file}", :info)
-        File.open(file,'w'){ |f| f.write(content) }
+        # force the encoding to be utf-8
+        File.open(file,'w'){ |f| f.write(content.force_encoding("UTF-8")) }
         return type, file
       end
 


### PR DESCRIPTION
Hi Mike,

Here is a small change that fixes (or masks?) the issue #11 with Sprint creating temp files and borking on files not encoded in utf-8.

Cheers.
