### PR TITLE
Remove a warning in Ruby 2.2

### DIFF
--- a/lib/mms2r.rb
+++ b/lib/mms2r.rb
@@ -23,12 +23,10 @@ module MMS2R
   # A hash of file extensions for common mime-types
 
   EXT = {
-    'text/plain' => 'text',
     'text/plain' => 'txt',
     'text/html' => 'html',
     'image/png' => 'png',
     'image/gif' => 'gif',
-    'image/jpeg' => 'jpeg',
     'image/jpeg' => 'jpg',
     'video/quicktime' => 'mov',
     'video/3gpp2' => '3g2'


### PR DESCRIPTION
Hashes don't support duplicate keys. This triggers a warning in Ruby 2.2.

There might still be a problem with this code not supporting the removed extensions, but this patch at least removes the warning.
